### PR TITLE
option: AllowNoFile() to hydrate configs even when a file is missing

### DIFF
--- a/fig_test.go
+++ b/fig_test.go
@@ -205,6 +205,31 @@ func Test_fig_Load_FileNotFound(t *testing.T) {
 	}
 }
 
+func Test_fig_Load_AllowNoFile(t *testing.T) {
+	fig := defaultFig()
+	fig.filename = "abrakadabra"
+	fig.allowNoFile = true
+	fig.useEnv = true
+	fig.envPrefix = ""
+
+	// Ensure that we still load values via env without a file
+	expectedKind := "this is required"
+	t.Setenv("KIND", expectedKind)
+	t.Setenv("METADATA_MASTER", "true")
+
+	var cfg Pod
+	err := fig.Load(&cfg)
+	if err != nil {
+		t.Fatalf("expected no err, got %v", err)
+	}
+	if cfg.Kind != expectedKind {
+		t.Fatalf("expected %q, got %q", expectedKind, cfg.Kind)
+	}
+	if cfg.Metadata.Master != true {
+		t.Fatalf("expected %t, got %v", true, cfg.Metadata.Master)
+	}
+}
+
 func Test_fig_Load_NonStructPtr(t *testing.T) {
 	cfg := struct {
 		X int

--- a/option.go
+++ b/option.go
@@ -118,3 +118,17 @@ func UseStrict() Option {
 		f.useStrict = true
 	}
 }
+
+// AllowNoFile returns an option that configures fig to proceed even when no config
+// file is found. Loading defaults and values from environment variables will still
+// work as expected.
+//
+//	fig.Load(&cfg, fig.AllowNoFile())
+//
+// If this option is not used then fig returns [ErrFileNotFound] as soon as none are
+// discovered.
+func AllowNoFile() Option {
+	return func(f *fig) {
+		f.allowNoFile = true
+	}
+}


### PR DESCRIPTION
When using fig.UseEnv(), values will similarly be pulled from the environment